### PR TITLE
Create gocheck init.d script

### DIFF
--- a/go/gocheck
+++ b/go/gocheck
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+# INIT INFO
+# Provides:          gocheck
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: gocheck daemon
+# Description:       gocheck daemon
+### END INIT INFO
+
+PATH=/usr/local/bin:/bin:/usr/bin
+NAME=gocheck
+DAEMON=/home/checker/go/gocheck
+PIDFILE=/var/run/$NAME.pid
+DESC="gocheck daemon"
+HOMEDIR=/home/checker/go
+USER=checker
+
+[ -x "$DAEMON" ] || exit 0
+
+. /lib/lsb/init-functions
+
+case "$1" in
+  start)
+    # master switch
+      log_daemon_msg "Starting $DESC" "$NAME"
+      /sbin/start-stop-daemon --start --chuid $USER --exec $DAEMON --chdir $HOMEDIR --background --make-pidfile --pidfile $PIDFILE
+      log_end_msg $?
+    ;;
+  stop)
+ # master switch
+      log_daemon_msg "Stopping $DESC" "$NAME"
+      /sbin/start-stop-daemon --stop --pidfile $PIDFILE --chuid $USER --exec $DAEMON
+      /bin/rm -f $PIDFILE
+      log_end_msg $?
+    ;;
+  reload|restart)
+    $0 stop && $0 start
+    ;;
+  status)
+ status_of_proc -p $PIDFILE $DAEMON $NAME && exit 0 || exit $?
+    ;;
+  *)
+    echo "Usage: /etc/init.d/$NAME {start|stop|restart|status}" >&2
+    exit 1
+    ;;
+esac
+
+exit 0


### PR DESCRIPTION
workaround for the upstart file that is used in the old version.

add info on how to attach it to init.d

sudo nano /etc/init.d/gocheck
sudo chmod 755 /etc/init.d/gocheck
sudo update-rc.d gocheck defaults

service gocheck start
service gocheck stop
service gocheck restart